### PR TITLE
fixed HIDEOUS, REPUGNANT grammar mistake

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
                 <h2><a href="https://crimemap.app">Crime Map</a></h2>
                 <p>A map of 911 calls made in Fayetteville and Springdale.<br><br>
 
-                    Made by <a href="https://puffyboa.xyz">Julian Sanker</a> and I as the winning entry for the <a href="https://www.jbu.edu/news/press-releases/?id=25122">2019 JB Hunt Hackathon</a><br><br>
+                    Made by <a href="https://puffyboa.xyz">Julian Sanker</a> and me as the winning entry for the <a href="https://www.jbu.edu/news/press-releases/?id=25122">2019 JB Hunt Hackathon</a><br><br>
                     
                     <a href="https://womack.house.gov/news/documentsingle.aspx?DocumentID=403780">2020 Congressional App Challenge winner for the AR-3 District</a><br><br>
                     


### PR DESCRIPTION
There was an appalling grammar error wherein the dazed kook by whom the content was authored wrote "I" instead of "me," effecting a dreadful and atrocious aberration of the English language. Weep, thou dazed kook!